### PR TITLE
Merge dev into main: fixes + skip reposts + idempotence

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ node start.js
 node web-monitor.js
 ```
 
-Web monitor: http://localhost:${WEB_MONITOR_PORT:-3001}
+Web monitor: [http://localhost:${WEB_MONITOR_PORT:-3001}](http://localhost:3001)
 
 ## What is TagKy?
 
@@ -95,3 +95,12 @@ Key variables (set in `./.env.local`):
 - `WEB_MONITOR_PORT`
 
 Note: Docker usage belongs to the monorepo root; this sub-repo is for the runnable build only.
+
+## Changelog
+
+- 2025-08-21
+  - Add Quick start section.
+  - Docker Compose updated to build directly from GitHub `dev` branch.
+  - Fix: prevent duplicate replies on container restart (idempotency in `fetcher.js`).
+  - Feature: skip tagging for empty-content posts (reposts) in `fetcher.js` and `worker.js`.
+  - Change: after `/tag on`, mark recent posts as processed to only tag future posts.

--- a/fetcher.js
+++ b/fetcher.js
@@ -210,6 +210,15 @@ async function handleFollowedUsersPosts() {
       if (!postUri) continue;
       if (isNotificationProcessed(postUri)) continue; // idempotent guard
       const content = p?.details?.content ?? p?.content ?? p?.body ?? null;
+      // Skip reposts or posts with empty content: do not enqueue tagging
+      if (!content || String(content).trim().length === 0) {
+        log.info('↩️ skip empty-content post (likely repost)', {
+          author_id: userId,
+          post_uri: postUri
+        });
+        markNotificationProcessed(postUri);
+        continue;
+      }
       log.info('🆕 new post from followed', {
         author_id: userId,
         post_uri: postUri,

--- a/worker.js
+++ b/worker.js
@@ -213,6 +213,13 @@ async function sendUnfollowExplanation(postUri) {
       try {
         markProcessing(j.id);
         
+        // Skip empty-content posts (e.g., reposts with no text)
+        if (!j.content || String(j.content).trim().length === 0) {
+          log.info('↩️ skip empty-content job (no tagging)', { id: j.id, post_uri: j.post_uri });
+          markIgnored(j.id, 'Empty content - skip tagging');
+          continue;
+        }
+
         // Ajouter le tag "en attente" au post
         try {
           await tagPostWithKeywords(j.post_uri, TAGKY_PENDING_TAG);


### PR DESCRIPTION
Summary:
- Fix duplicate confirmation replies on restart (idempotent mentions)
- Skip tagging for empty-content posts (reposts)
- After "/tag on", only tag future posts (mark recent as processed)
- Docker Compose: build from GitHub dev; docs: Quick start + Changelog

Rollback plan:
- If needed, revert the merge commit with: git revert -m 1 <merge_sha>
